### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-node_modules
-/build
+/node_modules/
+/build/
 /*.log


### PR DESCRIPTION
Added trailing slashes to follow recommended .gitignore syntax. It will now no
longer match a file called "build", but only a folder called "build".