### PR TITLE
Impoved mobile 404 page

### DIFF
--- a/src/routes/404/style.sss
+++ b/src/routes/404/style.sss
@@ -1,2 +1,6 @@
 .main404
   align-self: center
+  padding: 0 1em
+
+  & > video
+    max-width: 100%


### PR DESCRIPTION
Previously the mobile 404 page would have the video overflow out of the page on many devices.